### PR TITLE
Admin-user-can-add-remove-and-update-Interests

### DIFF
--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -29,7 +29,7 @@ input[type="submit"] {
   @include span-columns(8);
 }
 
-.org-form {
+.org-form, .interest-form{
   @include shift(3);
   @include span-columns(6);
   .simple_form > .field > .has-error {
@@ -40,7 +40,7 @@ input[type="submit"] {
       border-color: #ffacac;
       box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.06), 0 0 5px #ff0000;
     }
-  } 
+  }
 }
 
 .add-member {

--- a/app/controllers/interests_controller.rb
+++ b/app/controllers/interests_controller.rb
@@ -1,0 +1,61 @@
+class InterestsController < ApplicationController
+  before_action :set_interest, only: [:show, :edit, :update, :destroy]
+
+  def index
+    @interests = Interest.all
+  end
+
+  def show
+  end
+
+  def new
+    @interest = Interest.new
+  end
+
+  def edit
+  end
+
+  def create
+    @interest = Interest.new(interest_params)
+    respond_to do |format|
+      if @interest.save
+        format.html { redirect_to @interest, notice: 'Interest was successfully created.' }
+        format.json { render :show, status: :created, location: @interest }
+      else
+        format.html { render :new }
+        format.json { render json: @interest.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+
+  def update
+    respond_to do |format|
+      if @interest.update(interest_params)
+        format.html { redirect_to @interest, notice: 'Interest was successfully updated.' }
+        format.json { render :show, status: :ok, location: @interest }
+      else
+        format.html { render :edit }
+        format.json { render json: @interest.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  def destroy
+    @interest.destroy
+    respond_to do |format|
+      format.html { redirect_to interests_url, notice: 'Interest was successfully destroyed.' }
+      format.json { head :no_content }
+    end
+  end
+  
+private
+  def set_interest
+    @interest = Interest.find(params[:id])
+  end
+
+
+  def interest_params
+    params.require(:interest).permit(:interest)
+  end
+end

--- a/app/views/interests/_form.html.erb
+++ b/app/views/interests/_form.html.erb
@@ -1,0 +1,8 @@
+<%= form_for(interest) do |f| %>
+  <div class="field">
+    <%= f.text_field :interest, autofocus: true %>
+  </div>
+  <div class="actions">
+    <%= f.submit %>
+  </div>
+<% end %>

--- a/app/views/interests/edit.html.erb
+++ b/app/views/interests/edit.html.erb
@@ -1,0 +1,4 @@
+<div class="interest-form">
+  <h2>Edit Interest</h2>
+  <%= render partial: "form", locals: {interest: @interest}  %>
+</div>

--- a/app/views/interests/index.html.erb
+++ b/app/views/interests/index.html.erb
@@ -1,0 +1,15 @@
+<div class="create_interest">
+  <%= link_to "Add Interest", new_interest_path %>
+</div>
+<table>
+  <tbody>
+    <% @interests.each do |interest| %>
+      <tr>
+        <td><%= interest.interest %></td>
+        <td><%= link_to 'Show', interest %></td>
+        <td><%= link_to 'Edit', edit_interest_path(interest) %></td>
+        <td><%= link_to 'Destroy',interest, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/interests/new.html.erb
+++ b/app/views/interests/new.html.erb
@@ -1,0 +1,4 @@
+<div class="interest-form">
+  <h2>New Interest</h2>
+  <%= render partial: "form" ,locals: {interest: @interest} %>
+</div>

--- a/app/views/interests/show.html.erb
+++ b/app/views/interests/show.html.erb
@@ -1,0 +1,5 @@
+<div interest-form>
+    <h2><%=@interest.interest%></h2>
+    <%=link_to 'Add New Interest', new_interest_path, html_options = {type: "submit"} %>
+    <%=link_to 'Edit Interest', edit_interest_path(@interest), html_options = {type: "submit"} %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,9 +6,16 @@ Rails.application.routes.draw do
     sessions: 'users/sessions',
     registrations: "users/registrations"
   }
+  
   resources :organizations, only: [:index, :show, :new, :edit, :update, :create] do
     put 'add_member', on: :member
   end
+
+  resources :interests
+
+  get 'edit', to: 'interests#edit'
+  get 'new', to: 'interests#new'
+  delete 'destroy', to: 'interests#destroy'
 
   get '/search/users', to: 'search#users', as: 'search_users'
   get '/search/organizations', to: 'search#organizations', as: 'search_organizations'

--- a/spec/controllers/interest_controller_spec.rb
+++ b/spec/controllers/interest_controller_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+require 'spec_helper'
+
+
+describe InterestsController do
+  describe "managing interests" do
+
+    before do
+      Interest.create(interest: "cyclebar")
+    end
+
+    context "adding interests" do
+      it "can add an interest" do
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "editing interests" do
+      it "can edit an interest" do
+        likes = Interest.find_by(interest: 'cyclebar')
+        likes.interest = 'solidcore'
+        likes.save
+        response.should be_successful
+      end
+    end
+
+    context "destroy interests"  do
+      it "can destroy an interest" do
+        Interest.find_by(interest: 'cyclebar').destroy
+        expect(@interest).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
Resolves issue #46

This PR adds the ability to update, add and destroy interests for the admin user. Functionality to be added after issue #65 is added. 