### PR TITLE
Stub Geocoder #near Resolves #74

### DIFF
--- a/spec/features/user_spec.rb
+++ b/spec/features/user_spec.rb
@@ -60,6 +60,7 @@ describe "the signin process" do
 end
 
 describe 'the search process' do
+
   context 'when clicking the "Find Users" button' do
     let(:user) { create(:user) }
 

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -73,9 +73,14 @@ describe Organization, type: :model do
         }
     end
 
+    distances = [
+      [40.7484, -73.9857],  200
+    ]
+
     Geocoder.configure(:lookup => :test)
     addresses.each { |lookup, results| Geocoder::Lookup::Test.add_stub(lookup, [results]) }
-    addresses.each { |near, results| Geocoder::Lookup::Test.add_stub(near, [results]) }
+    Geocoder.configure(:near => :test)
+    distances.each { |near, results| Geocoder::Lookup::Test.add_stub(near, [results]) }
   end
 
   context 'when all organization attributes exist' do
@@ -205,14 +210,14 @@ describe Organization, type: :model do
 
     describe '.search_by_distance' do 
      it 'returns organization within a certain distance' do
-      expect(described_class.search_by_distance(user_one, rand(200..500)))
+      expect(described_class.search_by_distance(user_one, 200))
         .to include(org_one, org_two)
      end
 
      it 'does NOT return organizations outside of the range' do
-      expect(described_class.search_by_distance(user_one, rand(20..50)))
+      expect(described_class.search_by_distance(user_one, 25))
         .to include(org_one)
-      expect(described_class.search_by_distance(user_one, rand(20..50)))
+      expect(described_class.search_by_distance(user_one, 25))
         .not_to include(org_two)
      end
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -54,8 +54,8 @@ describe User, type: :model do
             'country_code' => 'US'
         },
         "350 Fifth Avenue New York, NY 10118" => {
-            'latitude'     => 40.7143528,
-            'longitude'    => -74.0059731,
+            'latitude'     => 40.748817,
+            'longitude'    => -73.985428,
             'street'      => '350 Fifth Avenue',
             'state'        => 'New York',
             'state_code'   => 'NY',
@@ -78,12 +78,27 @@ describe User, type: :model do
             'state'        => 'Norwich',
             'country'      => 'United Kingdom',
             'country_code' => 'UK'
+        },
+        "405 Lexington Ave New York, NY 10174" => {
+            'latitude'     => 40.751652,
+            'longitude'    => -73.975311,
+            'street'      => '405 Lexington Ave',
+            'state'        => 'New York',
+            'state_code'   => 'NY',
+            'zipcode'      => '10174',
+            'country'      => 'United States',
+            'country_code' => 'US'
         }
       }
 
+      distances = [
+        [42.3597994, -71.0544602],  500
+      ]
+
       Geocoder.configure(:lookup => :test)
       addresses.each { |lookup, results| Geocoder::Lookup::Test.add_stub(lookup, [results]) }
-      addresses.each { |near, results| Geocoder::Lookup::Test.add_stub(near, [results]) }
+      Geocoder.configure(:near => :test)
+      distances.each { |near, results| Geocoder::Lookup::Test.add_stub(near, [results]) }
     end
 
     let(:user) { create(:user) }


### PR DESCRIPTION
Fixes failing tests due to Geocoder API, which requires stubbing #near.