### PR TITLE
Admin-user-can-add-remove-and-update-Skills

### DIFF
--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -29,7 +29,7 @@ input[type="submit"] {
   @include span-columns(8);
 }
 
-.org-form, .interest-form{
+.org-form, .interest-form, .skill-form{
   @include shift(3);
   @include span-columns(6);
   .simple_form > .field > .has-error {

--- a/app/controllers/skills_controller.rb
+++ b/app/controllers/skills_controller.rb
@@ -1,0 +1,63 @@
+class SkillsController < ApplicationController
+  before_action :set_skill, only: [:show, :edit, :update, :destroy]
+
+  def index
+    @skills = Skill.all
+  end
+
+  def show
+  end
+
+  def new
+    @skill = Skill.new
+  end
+
+  def edit
+  end
+
+  def create
+    @skill = Skill.new(skill_params)
+    respond_to do |format|
+      if @skill.save
+        format.html { redirect_to @skill, notice: 'Skill was successfully created.' }
+        format.json { render :show, status: :created, location: @skill }
+      else
+        format.html { render :new }
+        format.json { render json: @skill.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+
+  def update
+    respond_to do |format|
+      if @skill.update(skill_params)
+        format.html { redirect_to @skill, notice: 'Skill was successfully updated.' }
+        format.json { render :show, status: :ok, location: @skill }
+      else
+        format.html { render :edit }
+        format.json { render json: @skill.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  def destroy
+    @skill.destroy
+    respond_to do |format|
+      format.html { redirect_to skills_url, notice: 'Skill was successfully destroyed.' }
+      format.json { head :no_content }
+    end
+  end
+  
+private
+
+  def set_skill
+    @skill = Skill.find(params[:id])
+  end
+
+
+  def skill_params
+    params.require(:skill).permit(:id,:skill)
+  end
+end
+

--- a/app/views/skills/_form.html.erb
+++ b/app/views/skills/_form.html.erb
@@ -1,0 +1,8 @@
+<%= form_for(skill) do |f| %>
+  <div class="field">
+    <%= f.text_field :skill, autofocus: true %>
+  </div>
+  <div class="actions">
+    <%= f.submit %>
+  </div>
+<% end %>

--- a/app/views/skills/edit.html.erb
+++ b/app/views/skills/edit.html.erb
@@ -1,0 +1,4 @@
+<div class="skill-form">
+  <h2>Edit Skill</h2>
+  <%= render partial: "form", locals: {skill: @skill}  %>
+</div>

--- a/app/views/skills/index.html.erb
+++ b/app/views/skills/index.html.erb
@@ -1,0 +1,15 @@
+<div class="create_skill">
+  <%= link_to "Add Skill", new_skill_path %>
+</div>
+<table>
+  <tbody>
+    <% @skills.each do |skill| %>
+      <tr>
+        <td><%= skill.skill %></td>
+        <td><%= link_to 'Show', skill %></td>
+        <td><%= link_to 'Edit', edit_skill_path(skill) %></td>
+        <td><%= link_to 'Destroy',skill, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/skills/new.html.erb
+++ b/app/views/skills/new.html.erb
@@ -1,0 +1,4 @@
+<div class="skill-form">
+  <h2>New Skill</h2>
+  <%= render partial: "form", locals: {skill: @skill}  %>
+</div>

--- a/app/views/skills/show.html.erb
+++ b/app/views/skills/show.html.erb
@@ -1,0 +1,5 @@
+<div skill-form>
+    <h2><%=@skill.skill%></h2>
+    <%=link_to 'Add New Skill', new_skill_path, html_options = {type: "submit"} %>
+    <%=link_to 'Edit Skill', edit_skill_path(@skill), html_options = {type: "submit"} %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,12 @@ Rails.application.routes.draw do
   get 'new', to: 'interests#new'
   delete 'destroy', to: 'interests#destroy'
 
+  resources :skills
+
+  get 'edit', to: 'skills#edit'
+  get 'new', to: 'skills#new'
+  delete 'destroy', to: 'skills#destroy'
+  
   get '/search/users', to: 'search#users', as: 'search_users'
   get '/search/organizations', to: 'search#organizations', as: 'search_organizations'
 end

--- a/spec/controllers/interests_controller_spec.rb
+++ b/spec/controllers/interests_controller_spec.rb
@@ -1,12 +1,11 @@
 require 'rails_helper'
-require 'spec_helper'
-
 
 describe InterestsController do
   describe "managing interests" do
 
     before do
       Interest.create(interest: "cyclebar")
+      expect(Interest.find_by(interest: 'cyclebar')).not_to be_nil
     end
 
     context "adding interests" do
@@ -20,14 +19,14 @@ describe InterestsController do
         likes = Interest.find_by(interest: 'cyclebar')
         likes.interest = 'solidcore'
         likes.save
-        response.should be_successful
+        expect(response).to have_http_status(:ok)
       end
     end
 
     context "destroy interests"  do
       it "can destroy an interest" do
         Interest.find_by(interest: 'cyclebar').destroy
-        expect(@interest).to be_nil
+        expect(Interest.find_by(interest: 'cyclebar')).to be_nil
       end
     end
   end

--- a/spec/controllers/skills_controller_spec.rb
+++ b/spec/controllers/skills_controller_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+describe SkillsController do
+  describe "managing skills" do
+  
+    before do
+      Skill.create(skill: "Rspec")
+      expect(Skill.find_by(skill: 'Rspec')).not_to be_nil
+    end
+
+    context "adding skills" do
+      it "can add an skill" do
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "editing skills" do
+      it "can edit an skill" do
+        skills = Skill.find_by(skill: 'Rspec')
+        skills.skill = 'Business Development'
+        skills.save
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "destroy skills"  do
+      it "can destroy an skill" do
+        Skill.find_by(skill: 'Rspec').destroy
+        expect(Skill.find_by(skill: 'Rspec')).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
Resolves Issue #45

Adds the ability to add, update and delete a skill in an Admin capacity. 

Also removed `require 'spec_helper'` from interest_controller_spec because it's not necessary.